### PR TITLE
Add path to directories

### DIFF
--- a/binder/postBuild
+++ b/binder/postBuild
@@ -66,6 +66,7 @@ echo "dbms.default_database=amr" >> $CONF_FILE
 echo "dbms_security_procedures_unrestricted=apoc.,algo." >> $CONF_FILE
 echo "apoc.export.file.enabled=true" >> $CONF_FILE
 echo "apoc.import.file.enabled=true" >> $CONF_FILE
+echo "dbms.directories.plugins=${CONDA_DIR}/neo4j-community/labs" >> $CONF_FILE
 
 ## populate the default DB in neo4j with python script
 


### PR DESCRIPTION
The path to where apoc is installed needs to be added to the config in order to be accessible
apoc-{VERSION}-core is installed by default. If we need to install apoc-{VERSION}-all, this is possible
<img width="972" alt="Screenshot 2022-01-13 at 12 30 24" src="https://user-images.githubusercontent.com/1022396/149330752-3fa08c0f-5add-4f86-b7b9-827a5ffc9927.png">

cc @agiani99 @YojanaGadiya 

